### PR TITLE
quality of sent image is reduced to decrease upload time

### DIFF
--- a/app/screens/camera.js
+++ b/app/screens/camera.js
@@ -60,12 +60,13 @@ const CameraComponent = ({ onNavigate }) => {
 
     let takePicture = async () => {
         let options = {
-        quality: 1,
+        quality: 0.3,
         base64: true,
         exif: false
         };
         let image = await cameraRef.current.takePictureAsync(options);
         setImage(image);
+        console.log(details);
     }
 
     const saveImage = async () => {

--- a/app/screens/camera.js
+++ b/app/screens/camera.js
@@ -66,7 +66,6 @@ const CameraComponent = ({ onNavigate }) => {
         };
         let image = await cameraRef.current.takePictureAsync(options);
         setImage(image);
-        console.log(details);
     }
 
     const saveImage = async () => {


### PR DESCRIPTION
Burası bilgisayar ekranı tarzında yüksek çözünürlük olan fotoğraflarda 4mb sınırını aşabiliyordu o yüzden quality parametresi kısıldı
